### PR TITLE
Remove unneccessary closing parentheses from the readme of vscode-language-pack-hu

### DIFF
--- a/i18n/vscode-language-pack-hu/README.md
+++ b/i18n/vscode-language-pack-hu/README.md
@@ -3,7 +3,7 @@
 Ez a nyelvi csomag a VS Code felhasználói felületének magyar lokalizációját tartalmazza.
 
 ## Használat
-A magyar nyelvi csomag használatához a telepítés után állítsa be a `"locale": "hu"` értéket a `locale.json`-ban. Ehhez hozza elő a **parancspalettát** a `Ctrl+Shift+P` billentyűkombinációval, kezdje el gépelni a „config” szöveget a parancsok listájának szűréséhez, majd válassza a **Configure language** lehetőséget). További információ a [dokumentációban](https://go.microsoft.com/fwlink/?LinkId=761051) található.
+A magyar nyelvi csomag használatához a telepítés után állítsa be a `"locale": "hu"` értéket a `locale.json`-ban. Ehhez hozza elő a **parancspalettát** a `Ctrl+Shift+P` billentyűkombinációval, kezdje el gépelni a „config” szöveget a parancsok listájának szűréséhez, majd válassza a **Configure language** lehetőséget. További információ a [dokumentációban](https://go.microsoft.com/fwlink/?LinkId=761051) található.
 
 ## Közreműködés
 A lefordított szövegek itt találhatók meg:


### PR DESCRIPTION
PS: I've created the PR agains `master` because I don't think it's neccessary to publish a new version of the language pack for 1.21 because of this fix.