### PR TITLE
Fixed blank space in "miConfigureTask"

### DIFF
--- a/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
@@ -1114,7 +1114,7 @@
 			"miRunningTask": "Mostrar &&Tarefas Em Execução...",
 			"miRestartTask": "R&&einiciar Tarefa em Execução",
 			"miTerminateTask": "&&Finalizar Tarefa",
-			"miConfigureTask": "&& Configurar Tarefas...",
+			"miConfigureTask": "&&Configurar Tarefas...",
 			"miConfigureBuildTask": "Configurar Tarefas Padrão de Compilação...",
 			"accessibilityOptionsWindowTitle": "Opções de Acessibilidade",
 			"miCheckForUpdates": "Verificar Atualizações...",


### PR DESCRIPTION
There's a blank space in 'miConfigureTask' (after the &&), that is making the translation to Brazilian Portuguese, out of alignment with the rest of content in the menu.