### PR TITLE
Chinese formatDocument.label wrong translation fix

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -365,7 +365,7 @@
 			"hint1n": "第 {0} 行到第 {1} 行间进行了 1 次格式编辑",
 			"hintnn": "第 {1} 行到第 {2} 行间进行了 {0} 次格式编辑",
 			"no.provider": "当前没有安装“{0}”文件的格式化程序。",
-			"formatDocument.label": "设置文档的格式",
+			"formatDocument.label": "格式化文档",
 			"no.documentprovider": "当前没有安装“{0}”文件的文档格式化程序。",
 			"formatSelection.label": "设置选定内容的格式",
 			"no.selectionprovider": "当前没有安装“{0}”文件的选定项格式化程序。"


### PR DESCRIPTION
translation improvement for `formatDocument.label`