### PR TITLE
german: "rename" should start with capital letter

### DIFF
--- a/i18n/vscode-language-pack-de/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-de/translations/main.i18n.json
@@ -3488,7 +3488,7 @@
 		"vs/workbench/contrib/files/browser/fileActions": {
 			"newFile": "Neue Datei",
 			"newFolder": "Neuer Ordner",
-			"rename": "umbenennen",
+			"rename": "Umbenennen",
 			"delete": "Löschen",
 			"copyFile": "Kopieren",
 			"pasteFile": "Einfügen",


### PR DESCRIPTION
cause all other menu items start with capital letters as well