### PR TITLE
fix translation typo

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -5071,7 +5071,7 @@
 			"workbench.action.terminal.resizePaneDown": "向下调整窗格大小",
 			"workbench.action.terminal.focus": "聚焦到终端",
 			"workbench.action.terminal.focusNext": "聚焦到下一终端",
-			"workbench.action.terminal.focusPrevious": "聚焦到下一终端",
+			"workbench.action.terminal.focusPrevious": "聚焦到上一终端",
 			"workbench.action.terminal.paste": "粘贴到活动终端中",
 			"workbench.action.terminal.paste.short": "粘贴",
 			"workbench.action.terminal.selectDefaultShell": "选择默认 Shell",


### PR DESCRIPTION
`terminal.focusPrevious` should be translated to "聚焦到上一终端".