### PR TITLE
Fix French mistake

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -4065,7 +4065,7 @@
 		},
 		"vs/workbench/contrib/preferences/browser/keybindingWidgets": {
 			"defineKeybinding.oneExists": "1 commande existante a cette combinaison de touche",
-			"defineKeybinding.existing": "{0} commandes existantes ont ce combinaison de touche",
+			"defineKeybinding.existing": "{0} commandes existantes ont cette combinaison de touche",
 			"defineKeybinding.initial": "Appuyez sur la combinaison de touches souhaitée puis appuyez sur Entrée",
 			"defineKeybinding.chordsTo": "pression simultanée avec"
 		},


### PR DESCRIPTION
Fixing French mistake on [main translation file line 4068](https://github.com/microsoft/vscode-loc/blob/master/i18n/vscode-language-pack-fr/translations/main.i18n.json#L4068).

From :   
`{0} commandes existantes ont ce combinaison de touche`
To :    
`{0} commandes existantes ont cette combinaison de touche`