### PR TITLE
fix: Command, Ctrl and Super are shortcut names and don't need to be translated

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -46,10 +46,10 @@
 			"altKey": "Alt",
 			"windowsKey": "Windows",
 			"superKey": "Super",
-			"ctrlKey.long": "控件",
+			"ctrlKey.long": "Control",
 			"shiftKey.long": "Shift",
 			"altKey.long": "Alt",
-			"cmdKey.long": "命令",
+			"cmdKey.long": "Command",
 			"windowsKey.long": "Windows",
 			"superKey.long": "Super"
 		},
@@ -818,7 +818,7 @@
 			"ariaSearchNoResult": "为{1}找到了{0}",
 			"ariaSearchNoResultWithLineNum": "{0} 在 {2} 处找到 {1}",
 			"ariaSearchNoResultWithLineNumNoCurrentMatch": "{0} 已找到 {1}",
-			"ctrlEnter.keybindingChanged": "Ctrl+Enter now inserts line break instead of replacing all. You can modify the keybinding for editor.action.replaceAll to override this behavior."
+			"ctrlEnter.keybindingChanged": "Ctrl+Enter 现在由全部替换改为插入换行。你可以修改editor.action.replaceAll 的按键绑定以覆盖此行为。"
 		},
 		"vs/editor/contrib/codeAction/lightBulbWidget": {
 			"quickFixWithKb": "显示修补程序({0})",
@@ -4161,7 +4161,7 @@
 			"resetLabel": "重置按键绑定",
 			"showSameKeybindings": "显示相同的按键绑定",
 			"copyLabel": "复制",
-			"copyCommandLabel": "Copy Command ID",
+			"copyCommandLabel": "复制命令 ID",
 			"error": "编辑按键绑定时发生错误“{0}”。请打开 \"keybindings.json\" 文件并检查错误。",
 			"editKeybindingLabelWithKey": "更改键绑定 {0}",
 			"editKeybindingLabel": "更改键绑定",

--- a/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
@@ -45,13 +45,13 @@
 			"shiftKey": "Shift",
 			"altKey": "Alt",
 			"windowsKey": "Windows",
-			"superKey": "超級鍵",
+			"superKey": "Super",
 			"ctrlKey.long": "Control",
 			"shiftKey.long": "Shift",
 			"altKey.long": "Alt",
-			"cmdKey.long": "命令",
+			"cmdKey.long": "Command",
 			"windowsKey.long": "Windows",
-			"superKey.long": "超級鍵"
+			"superKey.long": "Super"
 		},
 		"vs/base/browser/ui/aria/aria": {
 			"repeated": "{0} (再次出現)",
@@ -818,7 +818,7 @@
 			"ariaSearchNoResult": "已為 {1} 找到 {0}",
 			"ariaSearchNoResultWithLineNum": "於 {2} 找到 {1} 的 {0}",
 			"ariaSearchNoResultWithLineNumNoCurrentMatch": "已找到 {1} 的 {0}",
-			"ctrlEnter.keybindingChanged": "Ctrl+Enter now inserts line break instead of replacing all. You can modify the keybinding for editor.action.replaceAll to override this behavior."
+			"ctrlEnter.keybindingChanged": "Ctrl+Enter 現在由全部替換改為插入換行。你可以修改editor.action.replaceAll 的按鍵綁定以覆蓋此行為。"
 		},
 		"vs/editor/contrib/codeAction/lightBulbWidget": {
 			"quickFixWithKb": "顯示修正 ({0})",
@@ -4162,7 +4162,7 @@
 			"resetLabel": "重設按鍵繫結關係",
 			"showSameKeybindings": "顯示相同的按鍵繫結關係",
 			"copyLabel": "複製",
-			"copyCommandLabel": "Copy Command ID",
+			"copyCommandLabel": "複製命令 ID",
 			"error": "編輯按鍵繫結關係時發生錯誤 '{0}'。請開啟 'keybindings.json' 檔案並檢查錯誤。",
 			"editKeybindingLabelWithKey": "變更按鍵繫結關係 {0}",
 			"editKeybindingLabel": "變更按鍵繫結關係",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2784308/64088673-2b219680-cd75-11e9-9f72-5c23f3839210.png)
