### PR TITLE
Remove BOM

### DIFF
--- a/i18n/vscode-language-pack-fr/README.md
+++ b/i18n/vscode-language-pack-fr/README.md
@@ -1,4 +1,4 @@
-﻿#  Module linguistique français pour VS Code
+# Module linguistique français pour VS Code
 
 Le module linguistique français fournit une expérience d'interface utilisateur localisée pour VS Code.
 
@@ -49,10 +49,9 @@ Nous remercions particulièrement les contributeurs de la communauté de l'avoir
 * Alain BUFERNE
 * Etienne Blanc-Coquand
 
-
 **Profitez-en !**
 
-#  French Language Pack for VS Code
+# French Language Pack for VS Code
 
 French Language Pack provides localized UI experience for VS Code.
 
@@ -103,6 +102,4 @@ Special thanks to community contributors for making it available.
 * Alain BUFERNE
 * Etienne Blanc-Coquand
 
-
 **Enjoy!**
-

--- a/i18n/vscode-language-pack-ko/README.md
+++ b/i18n/vscode-language-pack-ko/README.md
@@ -1,4 +1,4 @@
-﻿#  VS Code용 한국어 팩
+# VS Code용 한국어 팩
 
 한국어 팩은 지역화된 VS Code용 UI 환경을 제공합니다.
 
@@ -42,7 +42,7 @@
 
 **감사합니다.**
 
-#  Korean Language Pack for VS Code
+# Korean Language Pack for VS Code
 
 Korean Language Pack provides localized UI experience for VS Code.
 
@@ -85,4 +85,3 @@ Special thanks to community contributors for making it available.
 * Junseong Jang
 
 **Enjoy!**
-

--- a/i18n/vscode-language-pack-ru/README.md
+++ b/i18n/vscode-language-pack-ru/README.md
@@ -1,4 +1,4 @@
-﻿#  Языковой пакет для русского языка для VS Code
+# Языковой пакет для русского языка для VS Code
 
 Языковой пакет для русского языка содержит локализацию интерфейса VS Code.
 
@@ -27,7 +27,7 @@
 * Mikhail Zabaluev
 * Ivan
 * Svitlana Galianova
-* Aleksey Nemiro 
+* Aleksey Nemiro
 * sberbanker
 * Nikita Gryzlov
 * Veronika Kolesnikova
@@ -44,11 +44,11 @@
 * Andrei Makarov
 * Romanenko Alexey
 * Roman Sokolov
-* Andrei Pryymak 
+* Andrei Pryymak
 
 **Приятной работы!**
 
-#  Russian Language Pack for VS Code
+# Russian Language Pack for VS Code
 
 Russian Language Pack provides localized UI experience for VS Code.
 
@@ -58,7 +58,7 @@ Once installed, set `"locale": "ru"` in `locale.json` to load Russian Language P
 
 ## Contributing
 
-The translation strings are maintained in "DevTools - VS Code" project in Microsoft Localization Community Platform (MLCP). 
+The translation strings are maintained in "DevTools - VS Code" project in Microsoft Localization Community Platform (MLCP).
 
 If you'd like to participate in the effort either to contribute translation or improve translation, see [community localization page](https://aka.ms/vscodeloc) for more information.
 
@@ -77,7 +77,7 @@ Special thanks to community contributors for making it available.
 * Mikhail Zabaluev
 * Ivan
 * Svitlana Galianova
-* Aleksey Nemiro 
+* Aleksey Nemiro
 * sberbanker
 * Nikita Gryzlov
 * Veronika Kolesnikova
@@ -94,7 +94,6 @@ Special thanks to community contributors for making it available.
 * Andrei Makarov
 * Romanenko Alexey
 * Roman Sokolov
-* Andrei Pryymak 
+* Andrei Pryymak
 
 **Enjoy!**
-


### PR DESCRIPTION
Some README.md (fr, ko, ru) files contain a BOM.
This cause the main title on VSCode (1.39) marketplace to display incorrectly.

Also trim some lines and delete double empty lines.
