### PR TITLE
fix wrong word / different meaning

### DIFF
--- a/i18n/vscode-language-pack-de/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-de/translations/main.i18n.json
@@ -5823,7 +5823,7 @@
 		},
 		"vs/workbench/contrib/url/common/trustedDomainsValidator": {
 			"openExternalLinkAt": "Möchten Sie, dass {0} die externe Website öffnet?",
-			"open": "Eröffnungskurs",
+			"open": "Öffnen in Browser",
 			"copy": "Kopieren",
 			"cancel": "Abbrechen",
 			"configureTrustedDomains": "Vertrauenswürdige Domänen konfigurieren"


### PR DESCRIPTION
...fix "not really" german ..."Eröffnungskurs" is the german word for the price at the beginning of every trading day a share at stock market starts ...it´s simply the wrong word ...not an important fix but now it´s in german