### PR TITLE
...say it like you are german

### DIFF
--- a/i18n/vscode-language-pack-de/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-de/translations/main.i18n.json
@@ -3202,9 +3202,9 @@
 			"noLaunchConfiguration": "Zur weiteren Konfiguration des Debuggens und der Ausführung",
 			"openFolder": "Ordner öffnen",
 			"andconfigure": " und erstellen Sie eine launch.json-Datei.",
-			"simplyDebugAndRun": "Öffnen Sie eine Datei, die gedebuggt oder ausgeführt werden kann.",
+			"simplyDebugAndRun": "Öffnen Sie eine Datei, die debuggt oder ausgeführt werden kann.",
 			"openFile": "Datei öffnen",
-			"canBeDebuggedOrRun": "die gedebuggt oder ausgeführt werden können."
+			"canBeDebuggedOrRun": "die debuggt oder ausgeführt werden können."
 		},
 		"vs/workbench/contrib/debug/browser/debugActions": {
 			"openLaunchJson": "{0} öffnen",


### PR DESCRIPTION
...this is a good example for some glitches in the german languages, caused by the language itself ...it is not really wrong to say "gedebuggt" ...but, with this kind of conjugation you change the tense as well ...and it most of all, it´s not "well drafted" / nice to read