### PR TITLE
Fix typo ja

### DIFF
--- a/i18n/vscode-language-pack-ja/translations/extensions/emmet.i18n.json
+++ b/i18n/vscode-language-pack-ja/translations/extensions/emmet.i18n.json
@@ -38,7 +38,7 @@
 			"emmetExtensionsPath": "Emmet のプロファイルとスニペットを含むフォルダーへのパス。",
 			"emmetShowExpandedAbbreviation": "展開された Emmet 省略記法を候補として表示します。\n`\"inMarkupAndStylesheetFilesOnly\"` オプションは、html、haml、jade、slim、xml、xsl、css、scss、sass、less、stylus に適用されます。\n\"always\" オプションは markup/css に関係なくファイルのすべての部分に適用されます。",
 			"emmetShowAbbreviationSuggestions": "利用できる Emmet 省略記法を候補として表示します。スタイルシートや emmet.showExpandedAbbreviation を `\"never\"` に設定していると適用されません。",
-			"emmetIncludeLanguages": "既定でサポートされていない言語で Emmet 略語を有効にします。ここに、その言語と Emmet でサポートされる言語のマッピングを追加します。\n 例: `{\"vue-html\":\"html\"、\"javascript\":\"javascriptreact\"}`",
+			"emmetIncludeLanguages": "既定でサポートされていない言語で Emmet 略語を有効にします。ここに、その言語と Emmet でサポートされる言語のマッピングを追加します。\n 例: `{\"vue-html\":\"html\", \"javascript\":\"javascriptreact\"}`",
 			"emmetVariables": "Emmet のスニペットで使用される変数",
 			"emmetTriggerExpansionOnTab": "有効にすると、TAB キーを押したときに Emmet 省略記法が展開されます。",
 			"emmetPreferences": "Emmet の一部のアクションやリゾルバーの動作の変更に使用される基本設定。",


### PR DESCRIPTION
Hello, I fix typo in locale japan

It `、` should not contain inline code like this ↓

https://github.com/microsoft/vscode-loc/blob/85e1dfc89903ac9af53971cd914269613171cf48/i18n/vscode-language-pack-zh-hans/translations/extensions/emmet.i18n.json#L41

Thank you for review my PR!
