### PR TITLE
fix: correcting improper translation in reserved word and added translation of untranslated terms

### DIFF
--- a/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
@@ -3469,10 +3469,10 @@
 		},
 		"vs/workbench/contrib/debug/browser/welcomeView": {
 			"run": "Executar",
-			"openAFileWhichCanBeDebugged": "[Open a file](command:{0}) which can be debugged or run.",
-			"runAndDebugAction": "[Run and Debug{0}](command:{1})",
-			"customizeRunAndDebug": "Para personalizar Executar e Depurar [crie um arquivo launch.json](comando:{0}).",
-			"customizeRunAndDebugOpenFolder": "To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file."
+			"openAFileWhichCanBeDebugged": "[Abra um arquivo](command:{0}) que possa ser depurado ou executado.",
+			"runAndDebugAction": "[Executar e Depurar {0}](command:{1})",
+			"customizeRunAndDebug": "Para personalizar Executar e Depurar [crie um arquivo launch.json](command:{0}).",
+			"customizeRunAndDebugOpenFolder": "Para personalizar Executar e Depurar, [abra uma pasta](command:{0}) e crie um arquivo launch.json."
 		},
 		"vs/workbench/contrib/debug/browser/debugActionViewItems": {
 			"debugLaunchConfigurations": "Depurar configurações de lançamento",


### PR DESCRIPTION
Found it bad behavior at  Visual Studio Code, but only when i switched to location pt-br, more info [here](https://github.com/microsoft/vscode/issues/95161). I start investigate the strings related, and i found the bug;
- Keyword `command` inside translate strings should not be translated, like explained [here](https://github.com/microsoft/vscode/blob/0492ad649d0b086aa1b7225d4eba20622cc2075a/src/vs/workbench/contrib/debug/browser/welcomeView.ts#L122)
- Added some terms in Portuguese that were not translated