### PR TITLE
Fix French translation

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -1401,7 +1401,7 @@
 			"defaultConfigurations.title": "Substitutions de configuration par défaut",
 			"overrideSettings.description": "Configurez les paramètres d'éditeur à remplacer pour le langage {0}.",
 			"overrideSettings.defaultDescription": "Configurez les paramètres d'éditeur à remplacer pour un langage.",
-			"overrideSettings.errorMessage": "Ce paramètre ne prend pas en charge la configuration par langue.",
+			"overrideSettings.errorMessage": "Ce paramètre ne prend pas en charge la configuration par langage.",
 			"config.property.languageDefault": "Impossible d'inscrire '{0}'. Ceci correspond au modèle de propriété '\\\\[.*\\\\]$' permettant de décrire les paramètres d'éditeur spécifiques à un langage. Utilisez la contribution 'configurationDefaults'.",
 			"config.property.duplicate": "Impossible d'inscrire '{0}'. Cette propriété est déjà inscrite."
 		},
@@ -3235,7 +3235,7 @@
 			"schema.indentationRules.unIndentedLinePattern.pattern": "Modèle RegExp pour unIndentedLinePattern.",
 			"schema.indentationRules.unIndentedLinePattern.flags": "Indicateurs RegExp pour unIndentedLinePattern.",
 			"schema.indentationRules.unIndentedLinePattern.errorMessage": "Doit valider l'expression régulière `/^([gimuy]+)$/`.",
-			"schema.folding": "Paramètres de repliage de la langue.",
+			"schema.folding": "Paramètres de repliage du langage.",
 			"schema.folding.offSide": "Un langage adhère à la règle du hors-champ si les blocs dans ce langage sont exprimés par leur indentation. Si spécifié, les lignes vides appartiennent au bloc suivant.",
 			"schema.folding.markers": "Les marqueurs de langage spécifiques de repliage tels que '#region' et '#endregion'. Les regex de début et la fin seront testés sur le contenu de toutes les lignes et doivent être conçues de manière efficace.",
 			"schema.folding.markers.start": "Le modèle de RegExp pour le marqueur de début. L’expression régulière doit commencer par '^'.",


### PR DESCRIPTION
There is a confusion between "langue" (French, English...) and "langage" (Go, JavaScript...). This PR fixes it.