### PR TITLE
Fix french translation for closeRemote.title

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -5276,7 +5276,7 @@
 			"noHost.tooltip": "Ouvrir une fenêtre distante",
 			"status.host": "Hôte distant",
 			"cat.title": "{0}: {1}",
-			"closeRemote.title": "Fer&&mer la connexion à distance"
+			"closeRemote.title": "Fermer la connexion à distance"
 		},
 		"vs/workbench/contrib/remote/browser/tunnelView": {
 			"remote.tunnelsView.add": "Réacheminer un port...",


### PR DESCRIPTION
See [#2831](https://github.com/microsoft/vscode-remote-release/issues/2831) from microsoft/vscode-remote-release

I don't know where this label is used, I hope this is the correct one.

![image](https://user-images.githubusercontent.com/11942518/80813970-54781800-8bcb-11ea-9a02-baee72eba235.png)

I am quite surprise that some other labels also defines that '&&' characters, also in other languages, maybe there is some else to fix.