### PR TITLE
[es] better spanish translation in cloning repo dialog

### DIFF
--- a/i18n/vscode-language-pack-es/translations/extensions/git.i18n.json
+++ b/i18n/vscode-language-pack-es/translations/extensions/git.i18n.json
@@ -271,7 +271,7 @@
 			"repourl": "Dirección URL de repositorio",
 			"pick url": "Elija una dirección URL desde la que se va a clonar.",
 			"selectFolder": "Seleccione la ubicación del repositorio",
-			"cloning": "Clonación del repositorio git ' {0} '...",
+			"cloning": "Clonando el repositorio git ' {0} '...",
 			"proposeopen": "¿Desea abrir el repositorio clonado?",
 			"openrepo": "Abrir",
 			"openreponew": "Abrir en una ventana nueva",


### PR DESCRIPTION
In the cloning repository dialog, the translation says "Clonación del repositorio", an better translation is "Clonando el repositorio git"
![image](https://user-images.githubusercontent.com/9060388/83958743-9af80c80-a832-11ea-89e1-5086d268f246.png)
