### PR TITLE
:bug: Put the shortcut on Alt-x for Executer

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -1527,7 +1527,7 @@
 			"mSelection": "&&Sélection",
 			"mView": "Affic&&hage",
 			"mGoto": "Attei&&ndre",
-			"mRun": "&&Exécuter",
+			"mRun": "E&&xécuter",
 			"mTerminal": "&&Terminal",
 			"mWindow": "Fenêtre",
 			"mHelp": "&&Aide",


### PR DESCRIPTION
Alt-e is already used for Edition and this caused a conflict