### PR TITLE
Fix Korean typo

### DIFF
--- a/i18n/vscode-language-pack-ko/translations/extensions/git.i18n.json
+++ b/i18n/vscode-language-pack-ko/translations/extensions/git.i18n.json
@@ -271,7 +271,7 @@
 			"neverShowAgain": "다시 표시 안 함",
 			"notfound": "Git을 찾을 수 없습니다. 'git.path'를 사용하여 Git을 설치하거나 구성합니다.",
 			"updateGit": "Git 업데이트",
-			"git20": "Git {0}이(가) 설치된 것 같습니다. 코드는 2 이하의 Git에서 최적으로 작동합니다.",
+			"git20": "Git {0}이(가) 설치된 것 같습니다. VS Code는 2 이상의 Git에서 최적으로 작동합니다.",
 			"git2526": "설치된 Git {0}에 알려진 문제가 있습니다. Git 기능이 제대로 작동하도록 하려면 2.27 이상의 Git으로 업데이트하세요."
 		},
 		"dist/remoteSource": {


### PR DESCRIPTION
I corrected a Korean typo. 
"이하(less than or equal to)" is incorrect, shoud be "이상(greater than or equal to)".