### PR TITLE
将notebook 的 `在单元格上方执行` 改为`执行上方所有单元格`

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -5993,7 +5993,7 @@
 			"notebookActions.deleteCell": "删除单元格",
 			"notebookActions.editCell": "编辑单元格",
 			"notebookActions.execute": "执行单元格",
-			"notebookActions.executeAbove": "在单元格上方执行",
+			"notebookActions.executeAbove": "执行上方的所有单元格",
 			"notebookActions.executeAndFocusContainer": "Execute Cell and Focus Container",
 			"notebookActions.executeAndInsertBelow": "执行笔记本单元格并在下方插入",
 			"notebookActions.executeAndSelectBelow": "执行笔记本单元格并在下方选择",


### PR DESCRIPTION
原语句不通顺或难以理解