### PR TITLE
Update main.i18n.json

### DIFF
--- a/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
@@ -6161,7 +6161,7 @@
 		"vs/workbench/contrib/notebook/browser/controller/editActions": {
 			"autoDetect": "自動偵測",
 			"changeLanguage": "變更儲存格語言",
-			"clearAllCellsOutputs": "清除所有儲存格的輸出",
+			"clearAllCellsOutputs": "清除所有輸出",
 			"clearCellOutputs": "清除儲存格輸出",
 			"languageDescription": "({0}) - 目前的語言",
 			"languageDescriptionConfigured": "({0})",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37107237/136998381-cde66cf7-6cc8-41ef-be7a-55e64feeb635.png)
The string "清除所有儲存格的輸出" is too long.
The labels on the toolbar should be kept simple.