### PR TITLE
Update the translation for testing

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -8549,7 +8549,7 @@
 			"testProgressWithSkip.running": "正在运行测试，通过 {0}/{1} ({2}%, {3} 个已跳过)"
 		},
 		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": {
-			"testing": "正在测试"
+			"testing": "测试资源管理器"
 		},
 		"vs/workbench/contrib/testing/browser/theme": {
 			"testing.iconErrored": "测试资源管理器中“出错”图标的颜色。",


### PR DESCRIPTION
“正在测试” means it's doing a testing task

While here it should be intended to show that the view container is a test explorer, so "测试资源管理器" is more suitable

Or just simply `测试`，which means `test` is also fine.