### PR TITLE
[es] Fix translation string

### DIFF
--- a/i18n/vscode-language-pack-es/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-es/translations/main.i18n.json
@@ -5695,7 +5695,7 @@
 			"noFolderHelp": "Todavía no ha abierto una carpeta.\r\n[Abrir carpeta](command:{0})",
 			"noWorkspaceHelp": "Todavía no ha agregado una carpeta al área de trabajo.\r\n[Abrir carpeta](command:{0})",
 			"openEditorsIcon": "Vea el icono de la vista de editores abiertos.",
-			"remoteNoFolderHelp": "Conectado al control remoto.\r\n[Abra carpeta](command:{0})"
+			"remoteNoFolderHelp": "Conectado al control remoto.\r\n[Abrir carpeta](command:{0})"
 		},
 		"vs/workbench/contrib/files/browser/fileActions": {
 			"binFailed": "Error al eliminar usando la papelera de reciclaje. ¿Desea eliminar de forma permanente en su lugar?",


### PR DESCRIPTION
the open file dialog translation on WSL when there is not an open folder says "Abra carpeta", a better translation is "Abrir carpeta", this PR does that:
- Change "Open folder"->"Abra carpeta" to Abrir carpeta

![image](https://user-images.githubusercontent.com/9060388/144509722-da4bd215-38e8-48a4-bd22-44e6b83433a0.png)
