### PR TITLE
Consistencia en gramática para palabras 'Solo'

### DIFF
--- a/i18n/vscode-language-pack-es/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-es/translations/main.i18n.json
@@ -780,7 +780,7 @@
 			"label.toggleSelectionFind": "Buscar en selección",
 			"placeholder.find": "Buscar",
 			"placeholder.replace": "Reemplazar",
-			"title.matchesCountLimit": "Sólo los primeros {0} resultados son resaltados, pero todas las operaciones de búsqueda trabajan en todo el texto."
+			"title.matchesCountLimit": "Solo los primeros {0} resultados son resaltados, pero todas las operaciones de búsqueda trabajan en todo el texto."
 		},
 		"vs/editor/contrib/folding/folding": {
 			"editorGutter.foldingControlForeground": "Color del control plegable en el medianil del editor.",
@@ -1009,7 +1009,7 @@
 			"tooltip.explanation": "Ejecutar el comando {0}"
 		},
 		"vs/editor/contrib/message/messageController": {
-			"editor.readonly": "No se puede editar en un editor de sólo lectura",
+			"editor.readonly": "No se puede editar en un editor de solo lectura",
 			"messageVisible": "Indica si el editor muestra actualmente un mensaje insertado"
 		},
 		"vs/editor/contrib/multicursor/multicursor": {
@@ -1387,7 +1387,7 @@
 		},
 		"vs/platform/extensionManagement/common/abstractExtensionManagementService": {
 			"MarketPlaceDisabled": "Marketplace no está habilitado",
-			"Not a Marketplace extension": "Sólo se pueden reinstalar Extensiones del Marketplace",
+			"Not a Marketplace extension": "Solo se pueden reinstalar Extensiones del Marketplace",
 			"incompatible platform": "La extensión \"{0}\" no está disponible en {1} para {2}.",
 			"malicious extension": "No se puede instalar la extensión \"{0}\" ya que se informó de que era problemática.",
 			"multipleDependentsError": "No se puede desinstalar la extensión \"{0}\". Las extensiones \"{1}\" y \"{2}\", entre otras, dependen de esta.",
@@ -2381,7 +2381,7 @@
 			"descriptionEmptyValidation": "Se requiere una descripción.",
 			"details": "Especifique los detalles.",
 			"disableExtensions": "Deshabilitar todas las extensiones y volver a cargar la ventana",
-			"disableExtensionsLabelText": "Intente reproducir el problema después de {0}. Si el problema sólo se reproduce cuando las extensiones están activas, puede que haya un problema con una extensión.",
+			"disableExtensionsLabelText": "Intente reproducir el problema después de {0}. Si el problema solo se reproduce cuando las extensiones están activas, puede que haya un problema con una extensión.",
 			"extensionWithNoBugsUrl": "El notificador de problemas no puede crear un informe para esta extensión, ya que no especifica una dirección URL para notificar problemas. Consulte la página del catálogo de esta extensión para ver si hay otras instrucciones disponibles.",
 			"extensionWithNonstandardBugsUrl": "El notificador del problema no puede crear problemas para esta extensión. Visite {0} para informar de un problema.",
 			"issueSourceEmptyValidation": "Se requiere un origen del problema.",
@@ -2650,7 +2650,7 @@
 			"menus.scmSourceControl": "El menú de control de código fuente",
 			"menus.scmTitle": "El menú del título Control de código fuente",
 			"menus.statusBarRemoteIndicator": "Menú de indicador remoto en la barra de estado",
-			"menus.touchBar": "Barra táctil (sólo macOS)",
+			"menus.touchBar": "Barra táctil (solo macOS)",
 			"missing.altCommand": "El elemento de menú hace referencia a un comando alternativo `{0}` que no está definido en la sección 'commands'.",
 			"missing.command": "El elemento de menú hace referencia a un comando `{0}` que no está definido en la sección 'commands'.",
 			"missing.submenu": "El elemento de menú hace referencia a un submenú \"{0}\" que no está definido en la sección \"submenus\".",
@@ -5187,7 +5187,7 @@
 			"extensions.autoUpdate.false": "Las extensiones no se actualizan automáticamente.",
 			"extensions.autoUpdate.true": "Descarga e instala las actualizaciones de forma automática para todas las extensiones.",
 			"extensions.supportUntrustedWorkspaces": "Reemplazar el soporte de área de trabajo no confiable de una extensión. Las extensiones que usen \"true\" estarán siempre habilitadas. Las extensiones que usen \"limited\" estarán siempre habilitadas, y la extensión ocultará la funcionalidad que requiera confianza. Las extensiones que usen \"false\" solo se habilitarán cuando el área de trabajo sea de confianza.",
-			"extensions.supportUntrustedWorkspaces.false": "La extensión sólo se activará cuando el área de trabajo sea de confianza.",
+			"extensions.supportUntrustedWorkspaces.false": "La extensión solo se activará cuando el área de trabajo sea de confianza.",
 			"extensions.supportUntrustedWorkspaces.limited": "La extensión siempre estará habilitada, y la extensión ocultará la funcionalidad que requiere confianza.",
 			"extensions.supportUntrustedWorkspaces.supported": "Definir la configuración del soporte del área de trabajo no confiable para la extensión.",
 			"extensions.supportUntrustedWorkspaces.true": "La extensión estará siempre habilitada.",
@@ -5270,7 +5270,7 @@
 			"workbench.extensions.installExtension.arg.decription": "Identificador de extensión o URI de recurso VSIX",
 			"workbench.extensions.installExtension.description": "Instalar la extensión dada",
 			"workbench.extensions.installExtension.option.donotSync": "Cuando está habilitada, VS Code no sincronizar esta extensión cuando la sincronización de configuración está activada.",
-			"workbench.extensions.installExtension.option.installOnlyNewlyAddedFromExtensionPackVSIX": "Cuando se activa, VS Code se instala sólo las extensiones recién agregadas del paquete de extensiones VSIX. Esta opción sólo se tiene en cuenta al instalar un VSIX.",
+			"workbench.extensions.installExtension.option.installOnlyNewlyAddedFromExtensionPackVSIX": "Cuando se activa, VS Code se instala solo las extensiones recién agregadas del paquete de extensiones VSIX. Esta opción solo se tiene en cuenta al instalar un VSIX.",
 			"workbench.extensions.installExtension.option.installPreReleaseVersion": "Cuando está habilitada, VS Code instala la versión preliminar de la extensión, si está disponible.",
 			"workbench.extensions.search.arg.name": "Consulta para usar en la búsqueda",
 			"workbench.extensions.search.description": "Buscar una extensión específica",
@@ -5679,7 +5679,7 @@
 			"permissionDeniedSaveErrorSudo": "Error al guardar '{0}': Permisos insuficientes. Seleccione 'Reintentar como Sudo' para reintentarlo como superusuario.",
 			"readonlySaveError": "No se pudo guardar \"{0}\": el archivo es de solo lectura. Seleccione \"Sobrescribir\" para tratar de hacerlo editable.",
 			"readonlySaveErrorAdmin": "No se pudo guardar \"{0}\": el archivo es de solo lectura. Seleccione la opción de sobrescribir como administrador para reintentarlo como administrador.",
-			"readonlySaveErrorSudo": "No se pudo guardar '{0}': El archivo es de sólo lectura. Seleccione 'Sobrescribir como Sudo' para reintentar como superusuario.",
+			"readonlySaveErrorSudo": "No se pudo guardar '{0}': El archivo es de solo lectura. Seleccione 'Sobrescribir como Sudo' para reintentar como superusuario.",
 			"retry": "Reintentar",
 			"saveConflictDiffLabel": "{0} (en archivo) ↔ {1} (en {2}): resuelva el conflicto de guardado",
 			"saveElevated": "Reintentar como Admin...",
@@ -6459,7 +6459,7 @@
 			"notebook.undoRedoPerCell.description": "Indica si se debe utilizar una pila para deshacer o rehacer separada para cada celda.",
 			"notebookConfigurationTitle": "Bloc de notas",
 			"showFoldingControls.always": "Los controles plegables siempre están visibles.",
-			"showFoldingControls.mouseover": "Los controles plegables sólo son visibles al pasar el mouse."
+			"showFoldingControls.mouseover": "Los controles plegables solo son visibles al pasar el mouse."
 		},
 		"vs/workbench/contrib/notebook/browser/notebookEditor": {
 			"fail.noEditor": "No se puede abrir el recurso con el tipo de editor de cuadernos \"{0}\"; compruebe que tenga instalada o habilitada la extensión correcta.",
@@ -6779,7 +6779,7 @@
 			"unsupportedProperty": "Propiedad no admitida",
 			"unsupportedRemoteMachineSetting": "Esta configuración no se puede aplicar en esta ventana. Se aplicará cuando abra una ventana local.",
 			"unsupportedWindowSetting": "No se puede aplicar esta configuración en esta área de trabajo. Se aplicará cuando abra directamente la carpeta de área de trabajo que la contiene.",
-			"untrustedSetting": "Esta configuración sólo puede aplicarse en un área de trabajo de confianza."
+			"untrustedSetting": "Esta configuración solo puede aplicarse en un área de trabajo de confianza."
 		},
 		"vs/workbench/contrib/preferences/browser/preferencesWidgets": {
 			"folderSettings": "Carpeta",
@@ -6861,7 +6861,7 @@
 			"settings.Modified": "Modificado.",
 			"settingsContextMenuTitle": "Más acciones... ",
 			"stopSyncingSetting": "Sincronizar esta configuración",
-			"trustLabel": "Esta configuración sólo puede aplicarse en un área de trabajo de confianza",
+			"trustLabel": "Esta configuración solo puede aplicarse en un área de trabajo de confianza",
 			"validationError": "Error de validación."
 		},
 		"vs/workbench/contrib/preferences/browser/settingsTreeModels": {
@@ -7429,7 +7429,7 @@
 			"search.files.result": "{0} resultado en {1} archivos",
 			"search.files.results": "{0} resultados en {1} archivos",
 			"searchCanceled": "La búsqueda se canceló antes de poder encontrar resultados - ",
-			"searchMaxResultsWarning": "El conjunto de resultados sólo contiene un subconjunto de todas las coincidencias. Sea más específico en su búsqueda para limitar los resultados.",
+			"searchMaxResultsWarning": "El conjunto de resultados solo contiene un subconjunto de todas las coincidencias. Sea más específico en su búsqueda para limitar los resultados.",
 			"searchPathNotFoundError": "No se encuentra la ruta de búsqueda: {0}",
 			"searchScope.excludes": "archivos para excluir",
 			"searchScope.includes": "archivos para incluir",
@@ -7497,7 +7497,7 @@
 			"numResults": "{0} resultados",
 			"oneFile": "1 archivo",
 			"oneResult": "1 resultado",
-			"searchMaxResultsWarning": "El conjunto de resultados sólo contiene un subconjunto de todas las coincidencias. Sea más específico en su búsqueda para limitar los resultados."
+			"searchMaxResultsWarning": "El conjunto de resultados solo contiene un subconjunto de todas las coincidencias. Sea más específico en su búsqueda para limitar los resultados."
 		},
 		"vs/workbench/contrib/snippets/browser/configureSnippets": {
 			"bad_name1": "Nombre de archivo no válido",
@@ -10279,7 +10279,7 @@
 			"permissionDeniedSaveErrorSudo": "Error al guardar '{0}': Permisos insuficientes. Seleccione 'Reintentar como Sudo' para reintentarlo como superusuario.",
 			"readonlySaveError": "No se pudo guardar \"{0}\": el archivo es de solo lectura. Seleccione \"Sobrescribir\" para tratar de hacerlo editable.",
 			"readonlySaveErrorAdmin": "No se pudo guardar \"{0}\": el archivo es de solo lectura. Seleccione la opción de sobrescribir como administrador para reintentarlo como administrador.",
-			"readonlySaveErrorSudo": "No se pudo guardar '{0}': El archivo es de sólo lectura. Seleccione 'Sobrescribir como Sudo' para reintentar como superusuario.",
+			"readonlySaveErrorSudo": "No se pudo guardar '{0}': El archivo es de solo lectura. Seleccione 'Sobrescribir como Sudo' para reintentar como superusuario.",
 			"retry": "Reintentar",
 			"saveAs": "Guardar como...",
 			"saveElevated": "Reintentar como Administrador...",


### PR DESCRIPTION
Se corrige la palabra 'solo' sin acentos para mejorar la consistencia del uso sin comillas aceptado por la RAE en todo el archivo JSON.