### PR TITLE
Revert "Update engine and version package.json"

### DIFF
--- a/i18n/vscode-language-pack-cs/package.json
+++ b/i18n/vscode-language-pack-cs/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-cs",
 	"displayName": "Czech Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Czech",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-de/package.json
+++ b/i18n/vscode-language-pack-de/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-de",
 	"displayName": "German Language Pack for Visual Studio Code",
 	"description": "Language pack extension for German",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-es/package.json
+++ b/i18n/vscode-language-pack-es/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-es",
 	"displayName": "Spanish Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Spanish",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-fr/package.json
+++ b/i18n/vscode-language-pack-fr/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-fr",
 	"displayName": "French Language Pack for Visual Studio Code",
 	"description": "Language pack extension for French",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-it/package.json
+++ b/i18n/vscode-language-pack-it/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-it",
 	"displayName": "Italian Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Italian",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-ja/package.json
+++ b/i18n/vscode-language-pack-ja/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-ja",
 	"displayName": "Japanese Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Japanese",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-ko/package.json
+++ b/i18n/vscode-language-pack-ko/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-ko",
 	"displayName": "Korean(사용법) Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Korean",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-pl/package.json
+++ b/i18n/vscode-language-pack-pl/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-pl",
 	"displayName": "Polish Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Polish",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-pt-BR/package.json
+++ b/i18n/vscode-language-pack-pt-BR/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-pt-BR",
 	"displayName": "Portuguese (Brazil) Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Portuguese (Brazil)",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-qps-ploc/package.json
+++ b/i18n/vscode-language-pack-qps-ploc/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-qps-ploc",
 	"displayName": "Pseudo Language Language Pack",
 	"description": "Language pack extension for Pseudo Language",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-ru/package.json
+++ b/i18n/vscode-language-pack-ru/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-ru",
 	"displayName": "Russian Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Russian",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-tr/package.json
+++ b/i18n/vscode-language-pack-tr/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-tr",
 	"displayName": "Turkish Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Turkish",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-zh-hans/package.json
+++ b/i18n/vscode-language-pack-zh-hans/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-zh-hans",
 	"displayName": "Chinese (Simplified) (简体中文) Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Chinese (Simplified)",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",

--- a/i18n/vscode-language-pack-zh-hant/package.json
+++ b/i18n/vscode-language-pack-zh-hant/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-language-pack-zh-hant",
 	"displayName": "Chinese (Traditional) Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Chinese (Traditional)",
-	"version": "1.64.0",
+	"version": "1.64.4",
 	"publisher": "MS-CEINTL",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Reverts microsoft/vscode-loc#683

because this was due to the automation running in January when we didn't do a December release (because we never do)