### PR TITLE
Add missing whitespaces for the fr translation key `scm button sync description`

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/extensions/git.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/extensions/git.i18n.json
@@ -12,7 +12,7 @@
 			"scm button publish branch": "Publier la branche",
 			"scm button publish branch running": "Branche de publication...",
 			"scm button publish title": "$(cloud-upload) Publier les branches",
-			"scm button sync description": "{0}Synchroniser les modifications{1}{2}",
+			"scm button sync description": "{0} Synchroniser les modifications {1}{2}",
 			"scm button sync title": "{0} {1}{2}",
 			"syncing changes": "Synchronisation des modifications..."
 		},


### PR DESCRIPTION
Currently it looks like this :

![Capture d’écran 2022-06-14 à 15 40 13](https://user-images.githubusercontent.com/3460382/173591762-a83ff0f4-db92-44b2-af64-655f91c11bc8.png)

[Default](https://github.com/microsoft/vscode/blob/cf040aa0dbb10898e65c5ed899052189567a4c3f/extensions/git/src/actionButton.ts#L70) : `"{0} Sync Changes {1}{2}"`