### PR TITLE
Provided localizedLanguageName for Polish

### DIFF
--- a/i18n/vscode-language-pack-pl/package.json
+++ b/i18n/vscode-language-pack-pl/package.json
@@ -21,7 +21,7 @@
 			{
 				"languageId": "pl",
 				"languageName": "Polish",
-				"localizedLanguageName": "Polish",
+				"localizedLanguageName": "polski",
 				"translations": [
 					{
 						"id": "vscode",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/152140 Polish language identified with its English name (unlike other languages)