### PR TITLE
Provided localizedLanguageName for Czech

### DIFF
--- a/i18n/vscode-language-pack-cs/package.json
+++ b/i18n/vscode-language-pack-cs/package.json
@@ -21,7 +21,7 @@
 			{
 				"languageId": "cs",
 				"languageName": "Czech",
-				"localizedLanguageName": "Czech",
+				"localizedLanguageName": "čeština",
 				"translations": [
 					{
 						"id": "vscode",


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode/issues/152140 Polish language identified with its English name (unlike other languages)