### PR TITLE
ko-kr: remove unknown text on package name

### DIFF
--- a/i18n/vscode-language-pack-ko/package.json
+++ b/i18n/vscode-language-pack-ko/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-language-pack-ko",
-	"displayName": "Korean(사용법) Language Pack for Visual Studio Code",
+	"displayName": "Korean Language Pack for Visual Studio Code",
 	"description": "Language pack extension for Korean",
 	"version": "1.70.0",
 	"publisher": "MS-CEINTL",


### PR DESCRIPTION
"사용법" means "Usage" exactly, so what does "Korean(Usage) Language Pack" mean???

This reverts commit bd8c9ecc6888c05d968d79a3fe612c3cfcb6e803.