### PR TITLE
[ja] fix "line" translations froｍ "線" to "行"

### DIFF
--- a/i18n/vscode-language-pack-ja/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ja/translations/main.i18n.json
@@ -207,8 +207,8 @@
 		},
 		"vs/editor/browser/widget/diffEditorWidget": {
 			"diff.tooLarge": "一方のファイルが大きすぎるため、ファイルを比較できません。",
-			"diffInsertIcon": "差分エディターで挿入を示す線の装飾。",
-			"diffRemoveIcon": "差分エディターで削除を示す線の装飾。"
+			"diffInsertIcon": "差分エディターで挿入を示す行の装飾。",
+			"diffRemoveIcon": "差分エディターで削除を示す行の装飾。"
 		},
 		"vs/editor/browser/widget/diffReview": {
 			"blankLine": "空白",
@@ -543,7 +543,7 @@
 			"tabCompletion.off": "タブ補完を無効にします。",
 			"tabCompletion.on": "タブ補完は、tab キーを押したときに最適な候補を挿入します。",
 			"tabCompletion.onlySnippets": "プレフィックスが一致する場合に、タブでスニペットを補完します。'quickSuggestions' が無効な場合に最適です。",
-			"unfoldOnClickAfterEndOfLine": "折りたたまれた線の後の空のコンテンツをクリックすると線が展開されるかどうかを制御します。",
+			"unfoldOnClickAfterEndOfLine": "折りたたまれた行の後の空のコンテンツをクリックすると行が展開されるかどうかを制御します。",
 			"unicodeHighlight.allowedCharacters": "強調表示されていない許可される文字を定義します。",
 			"unicodeHighlight.allowedLocales": "許可されているロケールで一般的な Unicode 文字が強調表示されていません。",
 			"unicodeHighlight.ambiguousCharacters": "現在のユーザー ロケールで一般的な文字を除き、基本的な ASCII 文字と混同される可能性のある文字を強調表示するかどうかを制御します。",
@@ -1060,7 +1060,7 @@
 			"showPreviousInlineSuggestion": "前へ"
 		},
 		"vs/editor/contrib/lineSelection/browser/lineSelection": {
-			"expandLineSelection": "線の選択を展開する"
+			"expandLineSelection": "行全体を選択する"
 		},
 		"vs/editor/contrib/linesOperations/browser/linesOperations": {
 			"duplicateSelection": "選択範囲の複製",


### PR DESCRIPTION
Since some "line"s are mistranslated into "線", I propose to fix them.

A straight "line" == "線"
A "line" of code == "行"