### PR TITLE
Makes typo corrections for pl/miViewTesting translation

### DIFF
--- a/i18n/vscode-language-pack-pl/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pl/translations/main.i18n.json
@@ -9346,7 +9346,7 @@
 			"unhideTest": "Odkryj test"
 		},
 		"vs/workbench/contrib/testing/browser/testing.contribution": {
-			"miViewTesting": "T&estrowanie",
+			"miViewTesting": "Testowanie",
 			"noTestProvidersRegistered": "W tym obszarze roboczym nie znaleziono jeszcze żadnych testów.",
 			"searchForAdditionalTestExtensions": "Zainstaluj dodatkowe rozszerzenia testowe...",
 			"test": "Testowanie",


### PR DESCRIPTION
Makes typo corrections for [`pl/miViewTesting`](https://github.com/microsoft/vscode-loc/blob/main/i18n/vscode-language-pack-pl/translations/main.i18n.json#L9349) translation: ampersand character and reduntant `r` character.