### PR TITLE
Make patch smaller

### DIFF
--- a/build/release.yml
+++ b/build/release.yml
@@ -34,7 +34,7 @@ extends:
     buildSteps:
       - pwsh: |
           [version]$version = Get-Content -Raw ./package.json | ConvertFrom-Json | Select-Object -ExpandProperty version
-          $patch = Get-Date -Format yyyyMMddHHmm
+          $patch = Get-Date -Format yyyyMMddHH
           npm version "$($version.Major).$($version.Minor).$patch"
         displayName: Update version
         workingDirectory: $(Build.SourcesDirectory)/i18n/$(languagePack)


### PR DESCRIPTION
Unfortunately, the marketplace has a limitation:

>  It must be one to four numbers in the range 0 to 2147483647, with each number seperated by a period. It must contain at least one non-zero number.

So this changes removes the last 2 digits (the minutes). This has the following limitations:

* Language packs will not be able to be released multiple times in the same hour... but they are released weekly anyway so I don't see that being an issue.
* Language packs can only be released until the year 2147... which... if language packs are still a thing then I will be rolling in my grave