### PR TITLE
Polish Chinese translations related to “comments”.

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -4569,12 +4569,12 @@
 			"startDebugTextMate": "启动文本配对语法语法日志记录"
 		},
 		"vs/workbench/contrib/comments/browser/commentColors": {
-			"commentThreadActiveRangeBackground": "当前选定或悬停注释范围的背景色。",
-			"commentThreadActiveRangeBorder": "当前选定或悬停注释范围的边框颜色。",
-			"commentThreadRangeBackground": "注释范围的背景色。",
-			"commentThreadRangeBorder": "注释范围的边框颜色。",
-			"resolvedCommentBorder": "已解析评论的边框和箭头颜色。",
-			"unresolvedCommentBorder": "未解析评论的边框和箭头颜色。"
+			"commentThreadActiveRangeBackground": "当前选定或悬停评论范围的背景色。",
+			"commentThreadActiveRangeBorder": "当前选定或悬停评论范围的边框颜色。",
+			"commentThreadRangeBackground": "评论范围的背景色。",
+			"commentThreadRangeBorder": "评论范围的边框颜色。",
+			"resolvedCommentBorder": "已解决评论的边框和箭头颜色。",
+			"unresolvedCommentBorder": "未解决评论的边框和箭头颜色。"
 		},
 		"vs/workbench/contrib/comments/browser/commentGlyphWidget": {
 			"editorGutterCommentGlyphForeground": "编辑器装订线中评论字形的装饰颜色。",
@@ -4586,76 +4586,76 @@
 			"commentDeleteReactionDefaultError": "未能删除评论回应",
 			"commentDeleteReactionError": "未能删除评论回应: {0}。",
 			"commentToggleReaction": "切换反应",
-			"commentToggleReactionDefaultError": "切换注释反应失败",
-			"commentToggleReactionError": "切换注释反应失败: {0}。"
+			"commentToggleReactionDefaultError": "切换评论反应失败",
+			"commentToggleReactionError": "切换评论反应失败: {0}。"
 		},
 		"vs/workbench/contrib/comments/browser/commentReply": {
-			"newComment": "键入新注释",
+			"newComment": "添加评论",
 			"reply": "回复..."
 		},
 		"vs/workbench/contrib/comments/browser/comments.contribution": {
 			"comments.openPanel.deprecated": "此设置已弃用，取而代之的是 `comments.openView`。",
 			"comments.openView": "控制评论视图应何时打开。",
-			"comments.openView.file": "批注视图将在具有注释的文件处于活动状态时打开。",
-			"comments.openView.firstFile": "如果在此会话期间尚未打开注释视图，则它将在带注释文件处于活动状态的会话期间首次打开。",
-			"comments.openView.never": "注释视图永远不会打开。",
-			"comments.visible": "控制具有注释范围和注释的编辑器中注释栏和注释线程的可见性。注释仍可通过“注释”视图访问，并会导致以运行命令 “Comments: Toggle Editor Commenting” 切换注释的相同方式切换打开注释。",
+			"comments.openView.file": "批注视图将在具有评论的文件处于活动状态时打开。",
+			"comments.openView.firstFile": "如果在此会话期间尚未打开评论视图，则它将在带评论文件处于活动状态的会话期间首次打开。",
+			"comments.openView.never": "评论视图永远不会打开。",
+			"comments.visible": "控制具有评论范围和评论的编辑器中评论栏和评论线程的可见性。评论仍可通过“评论”视图访问，并会导致以运行命令 “Comments: Toggle Editor Commenting” 切换评论的相同方式切换打开评论。",
 			"commentsConfigurationTitle": "评论",
 			"openComments": "控制评论面板应何时打开。",
-			"useRelativeTime": "确定是否在注释时间戳中使用相对时间，(例如\"1 天前\")。"
+			"useRelativeTime": "确定是否在评论时间戳中使用相对时间，(例如\"1 天前\")。"
 		},
 		"vs/workbench/contrib/comments/browser/commentsController": {
 			"hasCommentingRange": "活动光标处的位置是否具有评论范围",
-			"pickCommentService": "选择 \"注释提供程序\""
+			"pickCommentService": "选择 \"评论提供程序\""
 		},
 		"vs/workbench/contrib/comments/browser/commentsEditorContribution": {
 			"comments.addCommand": "添加对当前所选内容的注释",
 			"comments.collapseAll": "折叠所有注释",
 			"comments.expandAll": "展开所有注释",
 			"comments.toggleCommenting": "切换编辑器注释",
-			"nextCommentThreadAction": "转到下一条评论串",
-			"previousCommentThreadAction": "转到上一个评论线程"
+			"nextCommentThreadAction": "转到下一条注释串",
+			"previousCommentThreadAction": "转到上一个注释线程"
 		},
 		"vs/workbench/contrib/comments/browser/commentService": {
-			"hasCommentingProvider": "打开的工作区是否具有注释或注释范围。"
+			"hasCommentingProvider": "打开的工作区是否具有评论或评论范围。"
 		},
 		"vs/workbench/contrib/comments/browser/commentsTreeViewer": {
-			"commentCount": "1 条注释",
+			"commentCount": "1 条评论",
 			"commentLine": "[Ln {0}]",
 			"commentRange": "[Ln {0}-{1}]",
-			"comments.view.title": "注释",
-			"commentsCount": "{0} 条注释",
+			"comments.view.title": "评论",
+			"commentsCount": "{0} 条评论",
 			"image": "图片",
 			"imageWithLabel": "图片: {0}",
 			"lastReplyFrom": "来自 {0} 的最新回复"
 		},
 		"vs/workbench/contrib/comments/browser/commentsView": {
 			"collapseAll": "全部折叠",
-			"comments.filter.ariaLabel": "筛选注释",
+			"comments.filter.ariaLabel": "筛选评论",
 			"comments.filter.placeholder": "筛选器(例如文本、作者)",
 			"expandAll": "全部展开",
-			"resourceWithCommentLabel": "{3} 中第 {1} 行第 {2} 列中来自 ${0} 的注释，源: {4}",
-			"resourceWithCommentThreadsLabel": "{0} 中的注释，完整路径: {1}",
-			"rootCommentsLabel": "当前工作区的注释",
+			"resourceWithCommentLabel": "{3} 中第 {1} 行第 {2} 列中来自 ${0} 的评论，源: {4}",
+			"resourceWithCommentThreadsLabel": "{0} 中的评论，完整路径: {1}",
+			"rootCommentsLabel": "当前工作区的评论",
 			"showing filtered results": "正在显示第 {0} 页(共 {1} 页)",
-			"totalUnresolvedComments": "{0} 未解析的注释"
+			"totalUnresolvedComments": "{0} 未解决的评论"
 		},
 		"vs/workbench/contrib/comments/browser/commentsViewActions": {
-			"comments": "注释",
+			"comments": "评论",
 			"commentsClearFilterText": "清除筛选器文本",
-			"focusCommentsFilter": "焦点注释筛选器",
-			"focusCommentsList": "焦点注释视图",
+			"focusCommentsFilter": "焦点评论筛选器",
+			"focusCommentsList": "焦点评论视图",
 			"resolved": "显示已解决",
-			"toggle resolved": "切换已解决注释",
-			"toggle unresolved": "切换未解决注释",
+			"toggle resolved": "切换已解决评论",
+			"toggle unresolved": "切换未解决评论",
 			"unresolved": "显示未解决"
 		},
 		"vs/workbench/contrib/comments/browser/commentThreadBody": {
 			"commentThreadAria": "使用 {0} 评论。{1} 评论线程。",
-			"commentThreadAria.withRange": "通过 {2} 注释行 {1} 上具有 {0} 注释的线程。{3}。"
+			"commentThreadAria.withRange": "通过 {2} 评论行 {1} 上具有 {0} 评论的线程。{3}。"
 		},
 		"vs/workbench/contrib/comments/browser/commentThreadHeader": {
-			"collapseIcon": "用于折叠审阅注释的图标。",
+			"collapseIcon": "用于折叠审阅评论的图标。",
 			"label.collapse": "折叠",
 			"startThread": "开始讨论"
 		},
@@ -4667,14 +4667,14 @@
 			"pickReactions": "选取反应..."
 		},
 		"vs/workbench/contrib/comments/common/commentContextKeys": {
-			"comment": "注释的上下文值",
-			"commentController": "与注释线程关联的注释控制器 ID",
-			"commentIsEmpty": "在注释没有输入时设置",
-			"commentThread": "注释线程的上下文值",
-			"commentThreadIsEmpty": "在注释线程没有注释时设置"
+			"comment": "评论的上下文值",
+			"commentController": "与评论线程关联的评论控制器 ID",
+			"commentIsEmpty": "在评论没有输入时设置",
+			"commentThread": "评论线程的上下文值",
+			"commentThreadIsEmpty": "在评论线程没有评论时设置"
 		},
 		"vs/workbench/contrib/comments/common/commentModel": {
-			"noComments": "此工作区中尚无注释。"
+			"noComments": "此工作区中尚无评论。"
 		},
 		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": {
 			"builtinProviderDisplayName": "内置"
@@ -10678,13 +10678,13 @@
 			"workspacesFound": "此文件夹包含多个工作区文件，是否打开? [了解更多]({0})有关工作区文件的详细信息。"
 		},
 		"vs/workbench/services/actions/common/menusExtensionPoint": {
-			"comment.actions": "贡献的注释上下文菜单，呈现为注释编辑器下方的按钮",
-			"comment.commentContext": "提供的注释上下文菜单，在注释线程速览视图中呈现为单个注释上的右键单击菜单。",
-			"comment.title": "贡献的注释标题菜单",
-			"commentThread.actions": "贡献的注释线程上下文菜单，呈现为注释编辑器下方的按钮",
-			"commentThread.editorActions": "贡献的注释编辑器操作",
-			"commentThread.title": "贡献的注释线程标题菜单",
-			"commentThread.titleContext": "提供的注释线程标题的速览上下文菜单，在注释线程的速览标题上呈现为右键单击菜单。",
+			"comment.actions": "贡献的评论上下文菜单，呈现为评论编辑器下方的按钮",
+			"comment.commentContext": "提供的评论上下文菜单，在评论线程速览视图中呈现为单个评论上的右键单击菜单。",
+			"comment.title": "贡献的评论标题菜单",
+			"commentThread.actions": "贡献的评论线程上下文菜单，呈现为评论编辑器下方的按钮",
+			"commentThread.editorActions": "贡献的评论编辑器操作",
+			"commentThread.title": "贡献的评论线程标题菜单",
+			"commentThread.titleContext": "提供的评论线程标题的速览上下文菜单，在评论线程的速览标题上呈现为右键单击菜单。",
 			"dup": "命令“{0}”在 `commands` 部分重复出现。",
 			"dupe.command": "菜单项引用的命令中默认和替代命令相同",
 			"file.newFile": "“新建文件...”快速选取，显示在欢迎页面和文件菜单上。",


### PR DESCRIPTION
Re-checked the wording based on the feedbacks of #1100, generally separating two kinds of comments which appear in the editor/code and code review discussions.

This PR refers to the latter case, updating the comments appearing in the discussions within the scenario of code review / pull requests. Take a typical example, the current translation of `commentReply-newComment` is 键入新注释, which is obviously inappropriate; have changed to 添加评论 in line 4593. Same with others.

BTW, changed the wording within `commentsEditorContribution` from 评论 to 注释 (Line 4616-4617), following the principle of 'comments apprearing in the code mean 注释'.