### PR TITLE
Fixed Russian terminal.copyCommand string

### DIFF
--- a/i18n/vscode-language-pack-ru/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ru/translations/main.i18n.json
@@ -9894,7 +9894,7 @@
 			"overviewRuler": "Обзор оформления команд линейки",
 			"rerun": "Вы хотите выполнить команду: {0}",
 			"terminal.configureCommandDecorations": "Настройка оформления команд",
-			"terminal.copyCommand": "Команда копирования",
+			"terminal.copyCommand": "Копировать команду",
 			"terminal.copyOutput": "Копировать выходные данные",
 			"terminal.copyOutputAsHtml": "Копирование выходных данных в формате HTML",
 			"terminal.learnShellIntegration": "Сведения об интеграции с оболочкой",


### PR DESCRIPTION
Fixed an issue with incorrect translation displayed on the screenshot

![изображение](https://github.com/microsoft/vscode-loc/assets/7449066/c8c1e06a-6d8b-4a3b-9f7d-732b4ee11dd4)
