### PR TITLE
Opt out of Continuous Release Signal

### DIFF
--- a/build/release.yml
+++ b/build/release.yml
@@ -30,6 +30,7 @@ extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
     publishExtension: true
+    useContinuousReleaseSignal: false
     usePreReleaseChannel: false
     workingDirectory: $(Build.SourcesDirectory)/i18n/$(languagePack)
     buildSteps:


### PR DESCRIPTION
Langauage Packs don't use the pre-release channel at all so we shouldn't use this signal at all.

cc @lszomoru