### PR TITLE
fix js-debug.createDiagnostics link ru, tr

### DIFF
--- a/i18n/vscode-language-pack-ru/translations/extensions/ms-vscode.js-debug.i18n.json
+++ b/i18n/vscode-language-pack-ru/translations/extensions/ms-vscode.js-debug.i18n.json
@@ -94,7 +94,7 @@
 			"debug.terminal.toggleAuto": "Переключение автоприсоединения Node.js терминала",
 			"debug.terminal.welcome": "[Терминал отладки JavaScript](command:extension.js-debug.createDebuggerTerminal)\r\n\r\nВы можете использовать терминал отладки JavaScript для отладки процессов Node.js, запущенных в командной строке.",
 			"debug.terminal.welcomeWithLink": "[Терминал отладки JavaScript](command:extension.js-debug.createDebuggerTerminal)\r\n\r\nВы можете использовать терминал отладки JavaScript для отладки процессов Node.js, запущенных в командной строке.\r\n\r\n[URL-адрес отладки](command:extension.js-debug.debugLink).",
-			"debug.unverifiedBreakpoints": "Не удалось установить некоторые точки останова. Если у вас возникла проблема, вы можете [устранить неполадки в конфигурации запуска] (команда:extension.js-debug.createDiagnostics).",
+			"debug.unverifiedBreakpoints": "Не удалось установить некоторые точки останова. Если у вас возникла проблема, вы можете [устранить неполадки в конфигурации запуска](command:extension.js-debug.createDiagnostics).",
 			"debugLink.label": "Открыть ссылку",
 			"edge.address.description": "IP-адрес или имя узла, которые прослушивает веб-представление, при отладке веб-представлений. Если этот параметр не установлен, он будет определен автоматически.",
 			"edge.attach.description": "Подключить к экземпляру Microsoft Edge уже в режиме отладки",

--- a/i18n/vscode-language-pack-tr/translations/extensions/ms-vscode.js-debug.i18n.json
+++ b/i18n/vscode-language-pack-tr/translations/extensions/ms-vscode.js-debug.i18n.json
@@ -94,7 +94,7 @@
 			"debug.terminal.toggleAuto": "Terminal Node.js Otomatik Eklemeyi Aç/Kapat",
 			"debug.terminal.welcome": "[JavaScript Hata Ayıklama Terminali](command:extension.js-debug.createDebuggerTerminal)\r\n\r\nKomut satırında çalıştırılan Node.js işlemlerinde hata ayıklamak için JavaScript Hata Ayıklama Terminali'ni kullanabilirsiniz.",
 			"debug.terminal.welcomeWithLink": "[JavaScript Hata Ayıklama Terminali](command:extension.js-debug.createDebuggerTerminal)\r\n\r\nKomut satırında çalıştırılan Node.js işlemlerinde hata ayıklamak için JavaScript Hata Ayıklama Terminali'ni kullanabilirsiniz.\r\n\r\n[Hata Ayıklama URL'si](command:extension.js-debug.debugLink)",
-			"debug.unverifiedBreakpoints": "Kesme noktalarınızın bazıları ayarlanamadı. Bir sorun yaşıyorsanız, [başlatma yapılandırmanızda sorun gidermek] için extension.js-debug.createDiagnostics komutunu kullanın.",
+			"debug.unverifiedBreakpoints": "Kesme noktalarınızın bazıları ayarlanamadı. Bir sorun yaşıyorsanız, [başlatma yapılandırmanızda sorun gidermek](command:extension.js-debug.createDiagnostics) için komutunu kullanın.",
 			"debugLink.label": "Bağlantıyı Aç",
 			"edge.address.description": "Web görünümlerinde hata ayıklarken web görünümünün dinlediği IP adresi veya konak adı. Ayarlanmazsa otomatik olarak bulunur.",
 			"edge.attach.description": "Attach to an instance of Edge already in debug mode",


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode/issues/204671

I'm not an expert in turkish, but according to google translate the phrase remains valid