### PR TITLE
fix(zh-hans): vscode.emmet.i18n.json link

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/extensions/vscode.emmet.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/extensions/vscode.emmet.i18n.json
@@ -11,9 +11,9 @@
 		"bundle": {
 			"Emmet Abbreviation": "Emmet 缩写",
 			"Enter Abbreviation": "输入缩写",
-			"Invalid emmet.variables field. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "emmet.variables 字段无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration。",
-			"Invalid snippets file. See https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets for a valid example.": "代码段文件无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets。",
-			"Invalid syntax profile. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "语法配置无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration。"
+			"Invalid emmet.variables field. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "emmet.variables 字段无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 。",
+			"Invalid snippets file. See https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets for a valid example.": "代码段文件无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets 。",
+			"Invalid syntax profile. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "语法配置无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 。"
 		},
 		"package": {
 			"command.balanceIn": "平衡(向内)",
@@ -41,7 +41,7 @@
 			"command.wrapWithAbbreviation": "使用缩写包围",
 			"description": "适用于 VS Code 的 Emmet 支持",
 			"emmetExclude": "不应展开 Emmet 缩写的语言数组。",
-			"emmetExtensionsPath": "一组路径，其中每个路径都可以包含 Emmet syntaxProfiles 和/或代码片段。\r\n发生冲突时，后面路径的配置文件/代码段将重写以前的路径。\r\n有关详细信息和示例片段文件，请参见 https://code.visualstudio.com/docs/editor/emmet。",
+			"emmetExtensionsPath": "一组路径，其中每个路径都可以包含 Emmet syntaxProfiles 和/或代码片段。\r\n发生冲突时，后面路径的配置文件/代码段将重写以前的路径。\r\n有关详细信息和示例片段文件，请参见 https://code.visualstudio.com/docs/editor/emmet 。",
 			"emmetExtensionsPathItem": "包含 Emmet syntaxProfiles 和/或片段的路径。",
 			"emmetIncludeLanguages": "在默认不受支持的语言中启用 Emmet 缩写。在此语言和 Emmet 支持的语言之间添加映射。\r\n 例如: `{\"vue-html\": \"html\", \"javascript\": \"javascriptreact\"}`",
 			"emmetOptimizeStylesheetParsing": "当设置为 `false` 时，将分析整个文件并确定当前位置能否展开 Emmet 缩写。当设置为 `true` 时，将仅在 CSS/SCSS/LESS 文件中分析当前位置周围的内容。",

--- a/i18n/vscode-language-pack-zh-hans/translations/extensions/vscode.emmet.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/extensions/vscode.emmet.i18n.json
@@ -11,9 +11,9 @@
 		"bundle": {
 			"Emmet Abbreviation": "Emmet 缩写",
 			"Enter Abbreviation": "输入缩写",
-			"Invalid emmet.variables field. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "emmet.variables 字段无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 。",
-			"Invalid snippets file. See https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets for a valid example.": "代码段文件无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets 。",
-			"Invalid syntax profile. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "语法配置无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 。"
+			"Invalid emmet.variables field. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "emmet.variables 字段无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 了解更多。",
+			"Invalid snippets file. See https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets for a valid example.": "代码段文件无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_using-custom-emmet-snippets 了解更多。",
+			"Invalid syntax profile. See https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration for a valid example.": "语法配置无效。有关有效示例，请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 了解更多。"
 		},
 		"package": {
 			"command.balanceIn": "平衡(向内)",
@@ -41,7 +41,7 @@
 			"command.wrapWithAbbreviation": "使用缩写包围",
 			"description": "适用于 VS Code 的 Emmet 支持",
 			"emmetExclude": "不应展开 Emmet 缩写的语言数组。",
-			"emmetExtensionsPath": "一组路径，其中每个路径都可以包含 Emmet syntaxProfiles 和/或代码片段。\r\n发生冲突时，后面路径的配置文件/代码段将重写以前的路径。\r\n有关详细信息和示例片段文件，请参见 https://code.visualstudio.com/docs/editor/emmet 。",
+			"emmetExtensionsPath": "一组路径，其中每个路径都可以包含 Emmet syntaxProfiles 和/或代码片段。\r\n发生冲突时，后面路径的配置文件/代码段将重写以前的路径。\r\n有关详细信息和示例片段文件，请参见 https://code.visualstudio.com/docs/editor/emmet 了解更多。",
 			"emmetExtensionsPathItem": "包含 Emmet syntaxProfiles 和/或片段的路径。",
 			"emmetIncludeLanguages": "在默认不受支持的语言中启用 Emmet 缩写。在此语言和 Emmet 支持的语言之间添加映射。\r\n 例如: `{\"vue-html\": \"html\", \"javascript\": \"javascriptreact\"}`",
 			"emmetOptimizeStylesheetParsing": "当设置为 `false` 时，将分析整个文件并确定当前位置能否展开 Emmet 缩写。当设置为 `true` 时，将仅在 CSS/SCSS/LESS 文件中分析当前位置周围的内容。",


### PR DESCRIPTION
## Link to error 404

Periods are parsed as URLs and redirected to 404. Maybe the parsing rules can be changed? Or maybe I can use a stupid method like mine (I know it looks stupid)

https://github.com/microsoft/vscode-loc/blob/2be41b4282004642c243dc9de5634ed04f8d177d/i18n/vscode-language-pack-zh-hans/translations/extensions/vscode.emmet.i18n.json#L14-L16

```diff
- 请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration。
+ 请参阅 https://code.visualstudio.com/docs/editor/emmet#_emmet-configuration 了解更多。
```

https://code.visualstudio.com/docs/editor/emmet。
https://code.visualstudio.com/docs/editor/emmet