### PR TITLE
Fix a bad string translation in Brazilian Portuguese

### DIFF
--- a/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
@@ -5419,7 +5419,7 @@
 			"removeTimeout": "Remover Limite"
 		},
 		"vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint": {
-			"defaultHintAriaLabel": "Execute {0} para selecionar um idioma, execute {1} para preencher com o modelo ou execute {2} para abrir um editor diferente e começar. Comece a digitar para ignorar.",
+			"defaultHintAriaLabel": "Execute {0} para selecionar uma linguagem, execute {1} para preencher com o modelo ou execute {2} para abrir um editor diferente e começar. Comece a digitar para ignorar.",
 			"disableHint": " Alterne {0} nas configurações para desabilitar essa dica.",
 			"emptyHintText": "Pressione {0} para pedir para {1} fazer algo. ",
 			"emptyHintTextDismiss": "Comece a digitar para ignorar.",


### PR DESCRIPTION
The string is referring to programming languages, but the translation is talking about languages as in English.