### PR TITLE
Fix the "closedAllSaved" french translation

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -3796,7 +3796,7 @@
 			"binaryDiffEditor": "Éditeur de différences binaires",
 			"close": "Fermer",
 			"closeAll": "Tout fermer",
-			"closeAllSaved": "Fermer la version sauvegardée",
+			"closeAllSaved": "Fermer les onglets sauvegardés",
 			"closeEditor": "Fermer l'éditeur",
 			"closeEditorGroup": "Fermer le groupe d'éditeurs",
 			"closeEditorsInGroup": "Fermer tous les éditeurs du groupe",


### PR DESCRIPTION
"Fermer la version sauvegardée" means "Closed the saved version", but the feature actually closes the saved tabs, not a different version of the current file

The translation should be something like:
"Fermer les onglets sauvegardés" (closed saved tabs)
"Fermer les fichiers sauvegardés" (closed saved files)