### PR TITLE
i18n: Fix missing Chinese translation in debug welcomeView strings

### DIFF
--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -8790,8 +8790,8 @@
 		},
 		"vs/workbench/contrib/debug/browser/welcomeView": {
 			"allDebuggersDisabled": "禁用所有调试扩展。启用调试扩展或从市场安装新的扩展。",
-			"customizeRunAndDebug2": "To customize Run and Debug [create a launch.json file]({0}).",
-			"customizeRunAndDebugOpenFolder2": "To customize Run and Debug, [open a folder]({0}) and create a launch.json file.",
+			"customizeRunAndDebug2": "要自定义运行和调试，请[创建 launch.json 文件]({0})。",
+			"customizeRunAndDebugOpenFolder2": "要自定义运行和调试，请[打开一个文件夹]({0}) 并创建 launch.json 文件。",
 			"openAFileWhichCanBeDebugged": "[打开文件](command:{0})，可调试或运行。",
 			"run": "运行",
 			"runAndDebugAction": "运行和调试"


### PR DESCRIPTION
Update following keys:

- `customizeRunAndDebug2`
- `customizeRunAndDebugOpenFolder2`