### PR TITLE
Fix translation for session completion message

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -6221,7 +6221,7 @@
 			"agentSessions": "Sessions d’assistant",
 			"agentSessions.dragLabel": "{0} sessions d’assistant",
 			"chat.session.status.completed": "Terminé",
-			"chat.session.status.completedAfter": "Terminé dans {0}.",
+			"chat.session.status.completedAfter": "Terminé en {0}.",
 			"chat.session.status.failed": "Échec",
 			"chat.session.status.failedAfter": "Échec après {0}.",
 			"chat.session.status.inProgress": "Traitement en cours... Merci de patienter.",


### PR DESCRIPTION
"Terminé dans 12 s" is not the right translation. "dans" is used for (time) estimation, not for time passed.