### PR TITLE
Enable trigger for main branch in release pipeline

### DIFF
--- a/build/release.yml
+++ b/build/release.yml
@@ -6,10 +6,14 @@ name: $(Date:yyyyMMdd)$(Rev:.r)
 # This pipeline needs a variable called `languagePack` set to the name of the directory that
 # contains the language pack we want to work with. Set this via the Azure Pipelines UI.
 
+# Trigger a release when strings change in the main branch.
 trigger:
   branches:
     include:
       - main
+  paths:
+    include:
+      - i18n
 
 pr: none
 


### PR DESCRIPTION
Since vscode-loc-drop will only update language packs off the release branch of vscode, the cadance of when this runs will only be when strings change in the language pack.

This seems like a good heuristic to use to release the language packs.

One caveat, "changes" could mean that strings are added, in which case they will be English first... and _then_ changed to their language. This could mean that this releases twice in one week, and more if strings change via candidates.... but let's see how many this actually generates.