### PR TITLE
es: fix 'uma comilla' -> 'una comilla' in autoClosingQuotes description

### DIFF
--- a/i18n/vscode-language-pack-es/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-es/translations/main.i18n.json
@@ -413,7 +413,7 @@
 			"autoClosingComments": "Controla si el editor debe cerrar automáticamente los comentarios después de que el usuario agregue un comentario de apertura.",
 			"autoClosingDelete": "Controla si el editor debe quitar los corchetes o las comillas de cierre adyacentes al eliminar.",
 			"autoClosingOvertype": "Controla si el editor debe escribir entre comillas o corchetes.",
-			"autoClosingQuotes": "Controla si el editor debe cerrar automáticamente las comillas después de que el usuario agrega uma comilla de apertura.",
+			"autoClosingQuotes": "Controla si el editor debe cerrar automáticamente las comillas después de que el usuario agrega una comilla de apertura.",
 			"autoIndent": "Controla si el editor debe ajustar automáticamente la sangría mientras los usuarios escriben, pegan, mueven o sangran líneas.",
 			"autoIndentOnPaste": "Controla si el editor debe aplicar sangría automática automáticamente.",
 			"autoIndentOnPasteWithinString": "Controla si el editor deberá aplicar automáticamente sangría automática al contenido pegado cuando se pegue dentro de una cadena. Esto surte efecto cuando autoIndentOnPaste es verdadero.",


### PR DESCRIPTION
Closes #2216.

`i18n/vscode-language-pack-es/translations/main.i18n.json` line 416 (the `autoClosingQuotes` setting description) reads

> "...el usuario agrega **uma** comilla de apertura."

In Spanish the feminine indefinite article is `una`; `uma` is the Portuguese form. One-character fix; no other `uma`/`una` occurrences in this file were affected (verified with `grep`).