### PR TITLE
fix(ja): use && instead of & in selectFolder label

### DIFF
--- a/i18n/vscode-language-pack-ja/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ja/translations/main.i18n.json
@@ -2288,7 +2288,7 @@
 			"openFolder": "フォルダーを開く",
 			"openWorkspace": "開く(&&O)",
 			"openWorkspaceTitle": "ファイルでワークスペースを開く",
-			"selectFolder": "フォルダーの選択(&S)"
+			"selectFolder": "フォルダーの選択(&&S)"
 		},
 		"vs/platform/dnd/browser/dnd": {
 			"fileTooLarge": "ファイルが大きすぎて無題のエディターとして開けません。まずファイル エクスプローラーにアップロードしてから、もう一度お試しください。"


### PR DESCRIPTION
## Summary

Fix a typo in the Japanese translation where `selectFolder` used a single `&` instead of `&&`, causing the button label to render as literal text `フォルダーの選択(&S)` and preventing `Alt+S` from working.

## Changes

- `i18n/jpn/src/vs/platform/dialogs/electron-main/dialogMainService.i18n.json`
  - `"selectFolder"`: `"フォルダーの選択(&S)"` → `"フォルダーの選択(&&S)"`

## Motivation

The `openWorkspace` key in the same namespace already uses `&&O` correctly. This PR aligns `selectFolder` with the same convention.

## 概要

日本語翻訳ファイルの `selectFolder` で `&` が1つになっていたため、ボタンラベルに `フォルダーの選択(&S)` がそのまま表示され、`Alt+S` が機能しない問題を修正しました。

## 変更内容

- `i18n/jpn/src/vs/platform/dialogs/electron-main/dialogMainService.i18n.json`
  - `"selectFolder"`: `"フォルダーの選択(&S)"` → `"フォルダーの選択(&&S)"`

## 背景

同じ名前空間の `openWorkspace` はすでに `&&O` が正しく使われています。今回の修正はそれと同じ記法に統一するものです。