### PR TITLE
Fix french description of html.format.indentInnerHtml with backticks (issue #2250)

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/extensions/vscode.html-language-features.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/extensions/vscode.html-language-features.i18n.json
@@ -275,7 +275,7 @@
 			"html.format.enable.desc": "Activer/désactiver le formateur HTML par défaut.",
 			"html.format.extraLiners.desc": "Liste des balises, séparées par des virgules, qui devraient avoir un saut de ligne supplémentaire devant eux. `null` par défaut pour `\"head, body, /html\"`.",
 			"html.format.indentHandlebars.desc": "Mettez en forme et indenter `{{#foo}}`, ainsi que `{{/foo}}`.",
-			"html.format.indentInnerHtml.desc": "Mettez en retrait les sections '<head>' et '<body>'.",
+			"html.format.indentInnerHtml.desc": "Mettez en retrait les sections `<head>` et `<body>`.",
 			"html.format.maxPreserveNewLines.desc": "Nombre maximal de sauts de ligne à être conservés dans un segment unique. Utiliser `null` pour illimité.",
 			"html.format.preserveNewLines.desc": "Contrôle si les sauts de ligne existants avant des éléments doivent être préservés. Fonctionne uniquement avant des éléments, pas à l’intérieur de balises ou dans le texte.",
 			"html.format.templating.desc": "Privilégie les balises de langage de templating django, erb, handlebars et php.",


### PR DESCRIPTION
Fix issue [#2250](https://github.com/microsoft/vscode-loc/issues/2250) by replacing normal quotation marks with backticks. The pull request doesn't concern the translation itself, but rather the code syntax, and I know the solution, so I think I can make a pull request.