### PR TITLE
Fix French chat attach labels

### DIFF
--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -8426,8 +8426,8 @@
 			"chatContext.attach.placeholder": "Rechercher des pièces jointes",
 			"goBack": "Retour ↩",
 			"workbench.action.chat.attachContext.label.2": "Ajouter le contexte...",
-			"workbench.action.chat.attachFile.label": "Ajouter un fichier à la conversation",
-			"workbench.action.chat.attachFolder.label": "Ajouter un dossier à la conversation",
+			"workbench.action.chat.attachFile.label": "Ajouter le fichier à la conversation",
+			"workbench.action.chat.attachFolder.label": "Ajouter le dossier à la conversation",
 			"workbench.action.chat.attachPinnedEditors.label": "Ajoutez les éditeurs épinglés à la conversation",
 			"workbench.action.chat.attachSelection.label": "Ajouter la sélection à la conversation"
 		},


### PR DESCRIPTION
**Title:** Fix French translation for chat attach file/folder labels

### Summary
This PR fixes a minor translation inaccuracy in the French language pack for the Copilot chat attachment context menu. 

### Details
Previously, the translations for attaching a file or folder were:
- `Ajouter un fichier à la conversation` (Add *a* file to the conversation)
- `Ajouter un dossier à la conversation` (Add *a* folder to the conversation)

This implied that clicking the action would prompt the user to choose an undefined file or folder. However, since the user is right-clicking a specific file/folder to trigger this action, the definite article "le" is more accurate than the indefinite "un".

This PR updates the translations to:
- `Ajouter le fichier à la conversation` (Add *the* file to the conversation)
- `Ajouter le dossier à la conversation` (Add *the* folder to the conversation)

### Related Issue
Fixes #2359
