### PR TITLE
Restore electron-browser translation bundles removed in #2306

### DIFF
--- a/i18n/vscode-language-pack-cs/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-cs/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "True, když je fokus v zobrazení OTEVŘENÉ EDITORY",
 			"viewHasSomeCollapsibleItem": "True, pokud má pracovní prostor ve zobrazení EXPLORER nějaký sbalitelný kořenový podřízený prvek."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Soubor",
+			"miShare": "Sdílet",
+			"openContainer": "Open Containing Folder",
+			"revealInMac": "Reveal in Finder",
+			"revealInWindows": "Reveal in File Explorer"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Definuje výchozího zprostředkovatele rozsahu sbalování, který má přednost před všemi ostatními zprostředkovateli rozsahu sbalování. Musí se jednat o identifikátor rozšíření, které přispívá k poskytovateli rozsahu sbalování.",
 			"null": "Vše",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Místní historie"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Otevřít nadřazenou složku",
+			"revealInMac": "Zobrazit ve Finderu",
+			"revealInWindows": "Zobrazit v Průzkumníkovi souborů"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "ID jazyka",

--- a/i18n/vscode-language-pack-de/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-de/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "TRUE, wenn der Fokus innerhalb der Ansicht OPEN EDITORS liegt.",
 			"viewHasSomeCollapsibleItem": "True, wenn ein Arbeitsbereich in der EXPLORER-Ansicht über ein reduzierbares untergeordnetes Stammelement verfügt."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Datei",
+			"miShare": "Freigeben",
+			"openContainer": "Übergeordneten Ordner öffnen",
+			"revealInMac": "Im Finder anzeigen",
+			"revealInWindows": "Im Datei-Explorer anzeigen"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Definiert einen standardmäßigen Faltungsbereichsanbieter, der Vorrang vor allen anderen Faltungsbereichsanbietern hat. Muss der Bezeichner einer Erweiterung sein, die einen Faltungsbereichsanbieter beiträgt.",
 			"null": "Alle",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Lokaler Verlauf"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Übergeordneten Ordner öffnen",
+			"revealInMac": "Im Finder anzeigen",
+			"revealInWindows": "Im Datei-Explorer anzeigen"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "Sprach-ID",

--- a/i18n/vscode-language-pack-es/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-es/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "Es true cuando el foco está dentro de la vista EDITORES ABIERTOS.",
 			"viewHasSomeCollapsibleItem": "Es true cuando un área de trabajo de la vista del EXPLORADOR tiene un elemento secundario raíz contraíble."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Archivo",
+			"miShare": "Compartir",
+			"openContainer": "Abrir carpeta contenedora",
+			"revealInMac": "Mostrar en Finder",
+			"revealInWindows": "Mostrar en el Explorador de archivos"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Define un proveedor de rango de plegado por defecto que tiene prioridad sobre todos los demás proveedores de rango de plegado. Debe ser el identificador de una extensión que contribuya a un proveedor de rango de plegado.",
 			"null": "Todo",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Historial local"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Abrir carpeta contenedora",
+			"revealInMac": "Revelar en Finder",
+			"revealInWindows": "Mostrar en el Explorador de archivos"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "Id. de lenguaje",

--- a/i18n/vscode-language-pack-fr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-fr/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "La valeur est true quand la vue ÉDITEURS OUVERTS a le focus.",
 			"viewHasSomeCollapsibleItem": "La valeur est True quand un espace de travail de la vue EXPLORATEUR a un enfant racine réductible."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Fichier",
+			"miShare": "Partager",
+			"openContainer": "Ouvrir le dossier contenant",
+			"revealInMac": "Révéler dans le Finder",
+			"revealInWindows": "Révéler dans l'Explorateur de fichiers"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Définit un fournisseur de plages de pliage par défaut qui est prioritaire sur tous les autres fournisseurs de plages de pliage. Doit être l’identificateur d’une extension contribuant à un fournisseur de plage de pliage.",
 			"null": "Tous",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Historique local"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Ouvrir le dossier contenant",
+			"revealInMac": "Afficher dans le Finder",
+			"revealInWindows": "Afficher dans l'Explorateur de fichiers"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "ID de langage",

--- a/i18n/vscode-language-pack-it/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-it/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "È true quando lo stato attivo si trova all'interno della visualizzazione EDITOR APERTI.",
 			"viewHasSomeCollapsibleItem": "True quando un'area di lavoro nella visualizzazione ESPLORA RISORSE include un elemento figlio radice comprimibile."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "File",
+			"miShare": "Condividi",
+			"openContainer": "Apri cartella superiore",
+			"revealInMac": "Visualizza in Finder",
+			"revealInWindows": "Visualizza in Esplora file"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Definisce un provider di intervalli di riduzione predefinito che ha la precedenza su tutti gli altri provider di intervalli di riduzione. Deve essere l'identificatore di un'estensione che contribuisce a un provider di intervalli di riduzione.",
 			"null": "Tutto",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Cronologia locale"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Apri cartella superiore",
+			"revealInMac": "Visualizza in Finder",
+			"revealInWindows": "Visualizza in Esplora file"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "ID lingua",

--- a/i18n/vscode-language-pack-ja/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ja/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "[開いているエディター] ビュー内にフォーカスがある場合は True です。",
 			"viewHasSomeCollapsibleItem": "エクスプローラー ビューのワークスペースに折りたたみ可能なルートの子要素がある場合は True。"
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "ファイル",
+			"miShare": "共有",
+			"openContainer": "1 つ上のフォルダーを開く",
+			"revealInMac": "Finder で表示する",
+			"revealInWindows": "エクスプローラーで表示する"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "他のすべての折りたたみ範囲プロバイダーよりも優先される既定の折りたたみ範囲プロバイダーを定義します。折りたたみ範囲プロバイダーに貢献する拡張機能の識別子である必要があります。",
 			"null": "すべて",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "ローカル履歴"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "1 つ上のフォルダーを開く",
+			"revealInMac": "Finder で表示する",
+			"revealInWindows": "エクスプローラーで表示する"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "言語 ID",

--- a/i18n/vscode-language-pack-ko/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ko/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "포커스가 OPEN EDITORS 뷰 내에 있는 경우 true입니다.",
 			"viewHasSomeCollapsibleItem": "탐색기 보기의 작업 영역에 축소 가능한 루트 자식이 있는 경우 True입니다."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "파일",
+			"miShare": "공유",
+			"openContainer": "상위 폴더 열기",
+			"revealInMac": "Finder에 표시",
+			"revealInWindows": "파일 탐색기에 표시"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "다른 모든 접기 범위 공급자보다 우선하는 기본 접기 범위 공급자를 정의합니다. 접기 범위 공급자에 기여하는 확장의 식별자여야 합니다.",
 			"null": "모두",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "로컬 기록"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "상위 폴더 열기",
+			"revealInMac": "Finder에 표시",
+			"revealInWindows": "파일 탐색기에 표시"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "언어 ID",

--- a/i18n/vscode-language-pack-pl/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pl/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "Wartość true, gdy fokus znajduje się w obrębie widoku OTWARTE EDYTORY.",
 			"viewHasSomeCollapsibleItem": "Wartość true, gdy obszar roboczy w widoku EKSPLORATOR ma zwijany główny element podrzędny."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Plik",
+			"miShare": "Udostępnij",
+			"openContainer": "Open Containing Folder",
+			"revealInMac": "Pokaż w Finderze",
+			"revealInWindows": "Reveal in File Explorer"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Definiuje domyślnego dostawcę zakresu składania, który ma pierwszeństwo przed wszystkimi innymi dostawcami zakresu składania. Musi być identyfikatorem rozszerzenia współtworzącego dostawcę zakresu składania.",
 			"null": "Wszystko",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Historia lokalna"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Otwórz folder zawierający",
+			"revealInMac": "Pokaż w programie Finder",
+			"revealInWindows": "Wyświetl w Eksploratorze plików"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "Identyfikator języka",

--- a/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-pt-BR/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "True quando o foco está dentro da exibição EDITORES ABERTOS.",
 			"viewHasSomeCollapsibleItem": "True quando um espaço de trabalho na visualização EXPLORER tem algum filho raiz recolhível."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Arquivo",
+			"miShare": "Compartilhar",
+			"openContainer": "Abrir a Pasta",
+			"revealInMac": "Revelar no Finder",
+			"revealInWindows": "Revelar no Explorador de Arquivos"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Define um provedor de intervalo de dobragem padrão que tem precedência sobre todos os outros provedores de intervalo de dobragem. Deverá ser o identificador de uma extensão que contribui com um provedor de intervalo de dobragem.",
 			"null": "Tudo",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Histórico Local"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Abrir a pasta Contendo",
+			"revealInMac": "Revelar no Localizador",
+			"revealInWindows": "Revelar no Explorador de Arquivos"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "ID da Linguagem",

--- a/i18n/vscode-language-pack-qps-ploc/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-qps-ploc/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "Trµë whëñ thë føçµs ïs ïñsïðë thë ØPËÑ ËÐÏTØR§ vïëw.",
 			"viewHasSomeCollapsibleItem": "Trµë whëñ æ wørkspæçë ïñ thë ËXP£ØRËR vïëw hæs sømë çøllæpsïþlë røøt çhïlð."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Fïlë",
+			"miShare": "§hærë",
+			"openContainer": "Øpëñ Çøñtæïñïñg Følðër",
+			"revealInMac": "Rëvëæl ïñ Fïñðër",
+			"revealInWindows": "Rëvëæl ïñ Fïlë Ëxplørër"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Ðëfïñës æ ðëfæµlt følðïñg ræñgë prøvïðër thæt tækës prëçëðëñçë øvër æll øthër følðïñg ræñgë prøvïðërs. Mµst þë thë ïðëñtïfïër øf æñ ëxtëñsïøñ çøñtrïþµtïñg æ følðïñg ræñgë prøvïðër.",
 			"null": "Æll",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "£øçæl Hïstørÿ"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Øpëñ Çøñtæïñïñg Følðër",
+			"revealInMac": "Rëvëæl ïñ Fïñðër",
+			"revealInWindows": "Rëvëæl ïñ Fïlë Ëxplørër"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "£æñgµægë ÏÐ",

--- a/i18n/vscode-language-pack-ru/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-ru/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "Значение true, если фокус находится внутри представления \"Открытые редакторы\".",
 			"viewHasSomeCollapsibleItem": "ИСТИНА, если рабочая область в представлении EXPLORER имеет сворачиваемый корневой дочерний элемент."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Файл",
+			"miShare": "Поделиться",
+			"openContainer": "Открыть содержащую папку",
+			"revealInMac": "Отобразить в Finder",
+			"revealInWindows": "Открыть в проводнике"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Определяет поставщик диапазона свертывания по умолчанию, который получает приоритет над всеми другими поставщиками. Это должен быть ИД расширения, предоставляющего поставщик.",
 			"null": "Все",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Локальный журнал"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "Открыть содержащую папку",
+			"revealInMac": "Отобразить в Finder",
+			"revealInWindows": "Открыть в проводнике"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "Идентификатор языка",

--- a/i18n/vscode-language-pack-tr/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-tr/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "Odak AÇIK DÜZENLEYİCİLER görünümündeyse true olur.",
 			"viewHasSomeCollapsibleItem": "EXPLORER görünümündeki bir çalışma alanının daraltılabilir bir kök alt öğesi olduğunda true olur."
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "Dosya",
+			"miShare": "Paylaş",
+			"openContainer": "İçeren Klasörü Aç",
+			"revealInMac": "Finder'da Ortaya Çıkar",
+			"revealInWindows": "Dosya Gezgini'nde Göster"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "Diğer tüm katlama aralığı sağlayıcılarından daha öncelikli olan varsayılan bir kaynağa döndürme aralığı sağlayıcısı belirtir. Kaynağa döndürme aralığı sağlayıcısına katkıda bulunan bir uzantının tanımlayıcısı olmalıdır.",
 			"null": "Tümü",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "Yerel Geçmiş"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "İçeren Klasörü Aç",
+			"revealInMac": "Finder’da Göster",
+			"revealInWindows": "Dosya Gezgininde Göster"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "Dil Kimliği",

--- a/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hans/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "当焦点位于 OPEN EDITORS 视图内时为 True。",
 			"viewHasSomeCollapsibleItem": "如果资源管理器视图中的工作区具有一些可折叠的根子级，则为 true。"
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "文件",
+			"miShare": "共享",
+			"openContainer": "打开所在的文件夹",
+			"revealInMac": "在 Finder 中显示",
+			"revealInWindows": "在文件资源管理器中显示"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "定义优先于所有其他折叠范围提供程序的默认折叠范围提供程序。必须是提供折叠范围提供程序的扩展的标识符。",
 			"null": "全部",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "本地历史记录"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "打开包含文件夹",
+			"revealInMac": "在查找器中显示",
+			"revealInWindows": "在文件资源管理器中显示"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "语言 ID",

--- a/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
+++ b/i18n/vscode-language-pack-zh-hant/translations/main.i18n.json
@@ -14428,6 +14428,13 @@
 			"openEditorsFocus": "當焦點在 [開放式編輯器] 檢視中時為 true。",
 			"viewHasSomeCollapsibleItem": "當 [總管] 檢視中的工作區有一些可摺疊的根子系時，為 True。"
 		},
+		"vs/workbench/contrib/files/electron-browser/fileActions.contribution": {
+			"filesCategory": "檔案",
+			"miShare": "共用",
+			"openContainer": "開啟收納資料夾",
+			"revealInMac": "在 Finder 中顯示",
+			"revealInWindows": "在檔案總管中顯示"
+		},
 		"vs/workbench/contrib/folding/browser/folding.contribution": {
 			"formatter.default": "定義預設摺疊範圍提供者，使其優先於其他所有摺疊範圍提供者。必須是參與摺疊範圍提供者的延伸模組識別碼。",
 			"null": "全部",
@@ -14963,6 +14970,11 @@
 		},
 		"vs/workbench/contrib/localHistory/browser/localHistoryTimeline": {
 			"localHistory": "本機歷程記錄"
+		},
+		"vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands": {
+			"openContainer": "開啟內含資料夾",
+			"revealInMac": "在 Finder 中顯示",
+			"revealInWindows": "在檔案總管中顯示"
 		},
 		"vs/workbench/contrib/localization/common/localization.contribution": {
 			"language id": "語言識別碼",


### PR DESCRIPTION
## Summary

- Restores two translation bundles that were accidentally removed in the latest MLCP export (#2306):
  - `vs/workbench/contrib/files/electron-browser/fileActions.contribution`
  - `vs/workbench/contrib/localHistory/electron-browser/localHistoryCommands`
- These bundles are required at runtime for Explorer context menu items such as **Reveal in File Explorer** (Windows) / **Reveal in Finder** (macOS).
- Without them, VS Code falls back to English even when the Chinese (and other) language packs are installed.

Fixes #2295

## Root cause

PR #2306 moved `revealInWindows` / `revealInMac` / `openContainer` into `aiCustomizationManagement.contribution`, but VS Code reads these keys from the electron-browser bundles above. The correct bundles were deleted from all 14 language packs in that export.

## Test plan

- [ ] Install the updated Chinese (Simplified) language pack built from this branch
- [ ] Set display language to `zh-cn` and restart VS Code
- [ ] Right-click a file in Explorer → confirm **在文件资源管理器中显示** appears instead of **Reveal in File Explorer**
- [ ] Right-click a folder in Explorer → confirm the same reveal action is localized
- [ ] Confirm **Open in Integrated Terminal** shows **在集成终端中打开** (already fixed separately in #2306 via `scopedConsoleAction.Integrated`)

## Notes

Some menu items reported in #2295 are contributed by extensions and are out of scope for this repo (e.g. **Compile Files**, **CMSIS Configuration Wizard**, **Convert encoding to UTF8**, **Folder History**).

Made with [Cursor](https://cursor.com)